### PR TITLE
Add warning about MS Word, ensure MS Word plugin always up-to-date

### DIFF
--- a/App/AppInfo/Launcher/Custom.nsh
+++ b/App/AppInfo/Launcher/Custom.nsh
@@ -1,12 +1,45 @@
 ${SegmentFile}
 
 ${SegmentPre}
+	; Environment variables that can be used in the INI file
+
+	; Full path to "ZoteroPortable.exe" file
 	${SetEnvironmentVariablesPath} PAL:LAUNCHERPATH '$EXEPATH'
+	; Path to folder where "ZoteroPortable.exe" exist
 	${SetEnvironmentVariablesPath} PAL:LAUNCHERDIR '$EXEDIR'
+	; The launcher executable itself (ZoteroPortable.exe)
 	${SetEnvironmentVariablesPath} PAL:LAUNCHERFILE '$EXEFILE'
+	; Shortcut to "%UserProfile%\AppData\LocalLow" directory
 	${SetEnvironmentVariablesPath} LOCALAPPDATALOW '$PROFILE\AppData\LocalLow'
 !macroend
 
-${SegmentPost}
-	Delete '$APPDATA\Microsoft\Word\Startup\Zotero.*'
+${SegmentPreExecPrimary}
+	; Shortcut to Zotero Word plugin directory
+	StrCpy $1 '$EXEDIR\App\Zotero\extensions\zoteroWinWordIntegration@zotero.org\install'
+
+	${IfNot} ${FileExists} '$APPDATA\Microsoft\Word\Startup\Zotero.dotm'
+		; Always copy the latest version of Zotero Word plugin
+		; This will replace the outdated version (unlike FilesMove, which create a backup)
+		CopyFiles '$1\Zotero.dotm' '$APPDATA\Microsoft\Word\Startup\Zotero.dotm'
+
+		${If} ${ProcessExists} 'winword.exe'
+			; Show an error dialog if Microsoft Word is already running
+			MessageBox MB_OK|MB_ICONINFORMATION 'You may need to restart Microsoft Word to use the Zotero plugin.'
+		${EndIf}
+	${EndIf}
+!macroend
+
+${SegmentPostPrimary}
+	ClearErrors
+	; Delete the Zotero Word plugin
+	Delete '$APPDATA\Microsoft\Word\Startup\Zotero.dotm'
+
+	${If} ${Errors}
+		; Show an error dialog if Microsoft Word is still running
+		MessageBox MB_OK|MB_ICONEXCLAMATION 'Unable to delete Zotero plugin, is Microsoft Word still running? Postponing deletion until the next Zotero launch.'
+	${Else}
+		; Remove directory only if empty
+		RMDir '$APPDATA\Microsoft\Word\Startup'
+		RMDir '$APPDATA\Microsoft\Word'
+	${EndIf}
 !macroend

--- a/App/AppInfo/Launcher/ZoteroPortable.ini
+++ b/App/AppInfo/Launcher/ZoteroPortable.ini
@@ -38,21 +38,17 @@ HKCU\Software\Classes\zotero\=REG_SZ:zoteroProtocol
 HKCU\Software\Classes\zotero\URL Protocol=REG_SZ:
 HKCU\Software\Classes\zotero\shell\open\command\=REG_SZ:"%PAL:LauncherPath%" -url "%1"
 
-[FilesMove]
-Zotero\Plugin\Word\Zotero.dotm=%AppData%\Microsoft\Word\Startup
-
 [DirectoriesMove]
 -=%LocalAppData%\Zotero
 -=%AppData%\Zotero
 -=%HOMEPATH%\Zotero
 
 [DirectoriesCleanupIfEmpty]
-1=%AppData%\Microsoft\Word
-2=%LocalAppDataLow%\Mozilla
-3=%AppData%\Mozilla\Extensions
-4=%AppData%\Mozilla\SystemExtensionsDev
-5=%AppData%\Mozilla
-6=%PAL:DataDir%\Temp
+1=%LocalAppDataLow%\Mozilla
+2=%AppData%\Mozilla\Extensions
+3=%AppData%\Mozilla\SystemExtensionsDev
+4=%AppData%\Mozilla
+5=%PAL:DataDir%\Temp
 
 [FileWrite1]
 Type=Replace


### PR DESCRIPTION
I already implemented it a long time ago, but I'm too lazy to make a PR. Now that I started using Zotero again, may as well create this PR.

Basically it just adds a message if Microsoft Word is still running when launching/exiting Zotero Portable.

It also ensures MS Word plugin is always up to date (by replacing the outdated file, not creating a backup). On the previous version, the older plugin will continue to be used even if Zotero is updated to a newer version (because the plugin is stored as a copy in `Data\Zotero` directory).